### PR TITLE
Prepare for exnref native build

### DIFF
--- a/.github/workflows/wasix-pr.yaml
+++ b/.github/workflows/wasix-pr.yaml
@@ -45,7 +45,7 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           sysroot-tag: v2026-02-16.1
-          version: v0.3.0
+          version: v0.4.0
 
       - name: Tool Versions
         run: |

--- a/.github/workflows/wasix-pr.yaml
+++ b/.github/workflows/wasix-pr.yaml
@@ -45,7 +45,7 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           sysroot-tag: v2026-02-16.1
-          version: v0.4.0
+          version: v0.4.1
 
       - name: Tool Versions
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -135,6 +135,7 @@ config.h.in
 /scripts/php-config
 /scripts/phpize
 php
+php-debug.wasm
 php.wasm
 
 # ------------------------------------------------------------------------------

--- a/wasix-build-eh.sh
+++ b/wasix-build-eh.sh
@@ -4,13 +4,36 @@ set -eou
 
 make -j16
 
-wasm-opt -O3 \
-  --emit-exnref \
+# Some wasm-opt passes are not compatible with EH.
+# When generating debug info, we don't need to disable them but without debug info we do, otherwise wasm-opt crashes.
+# The offending passes are flatten, dae-optimizing and inlining-optimizing.
+
+# First asyncify while preserving debug info
+# O4 is only here for good measure, the important part is asyncify
+wasm-opt -g \
+  -O4 \
   --no-validation \
   --all-features \
-  --strip-debug \
+  --disable-gc \
+  --closed-world \
+  --skip-pass=flatten \
+  --skip-pass=dae-optimizing \
+  --skip-pass=inlining-optimizing \
   --asyncify \
   --pass-arg=asyncify-imports@wasix_32v1.proc_snapshot \
   --pass-arg=asyncify-ignore-indirect \
   --pass-arg=max-func-params@32 \
-  sapi/cli/php -o sapi/cli/php.wasm
+  sapi/cli/php -o sapi/cli/php-debug.wasm
+
+# A second wasm-opt run for stripping debug 
+# info and running full O4
+wasm-opt --strip-debug \
+  -O4 \
+  --no-validation \
+  --all-features \
+  --disable-gc \
+  --closed-world \
+  --skip-pass=flatten \
+  --skip-pass=dae-optimizing \
+  --skip-pass=inlining-optimizing \
+  sapi/cli/php-debug.wasm -o sapi/cli/php.wasm

--- a/wasix-configure-eh.sh
+++ b/wasix-configure-eh.sh
@@ -48,9 +48,9 @@ export \
   NM="wasixnm" \
   CC="wasixcc" \
   CXX="wasixcc++" \
-  CFLAGS="-g -flto -O2" \
-  CXXFLAGS="-g -flto -O2" \
-  LIBS="-L$PHP_WASIX_DEPS/lib-eh --no-wasm-opt" \
+  CFLAGS="-g -flto -O4" \
+  CXXFLAGS="-g -flto -O4" \
+  LIBS="-L$PHP_WASIX_DEPS/lib-eh --no-wasm-opt -g -flto -O4" \
   WASIXCC_INCLUDE_CPP_SYMBOLS="yes" \
   WASIXCC_WASM_EXCEPTIONS="yes" \
   PROG_SENDMAIL="/usr/bin/sendmail"
@@ -64,7 +64,7 @@ export \
   --enable-bcmath --enable-tidy --enable-gd --enable-exif --with-jpeg --with-freetype --with-webp \
   --enable-fiber-asm --with-curl --with-mysqli=mysqlnd --with-pdo-mysql=mysqlnd --with-zip --with-sodium \
   --with-pgsql="$PHP_WASIX_DEPS"/pgsql-eh --with-pdo-pgsql="$PHP_WASIX_DEPS"/pgsql-eh --enable-intl \
-  --with-pdo-sqlite --enable-ftp --enable-igbinary --with-imagick \
+  --with-pdo-sqlite --enable-ftp --enable-igbinary --with-imagick --enable-debug \
   --program-suffix=".wasm"
 
 ./wasix-build-eh.sh


### PR DESCRIPTION
Some changes to the build process that are required for an exnref exception handling build. Needs a published wasixcc version with exnref exception handling.